### PR TITLE
Close file only if it was successfully opened

### DIFF
--- a/template.go
+++ b/template.go
@@ -186,13 +186,13 @@ func BuildTemplate(dir string, files ...string) error {
 	var err error
 	fs := beeTemplateFS()
 	f, err := fs.Open(dir)
-	defer f.Close()
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
 		return errors.New("dir open err")
 	}
+	defer f.Close()
 
 	beeTemplates, ok := beeViewPathTemplates[dir]
 	if !ok {


### PR DESCRIPTION
I use beego along with go-bindata. 
When `BuildTemplate` tries to open non-existent file go-bindata returns `nil` as file with err set to `os.ErrNotExist`. And `defer f.Close()` called before checking errors. So when `f.Close()` gets executed app panics with `panic: runtime error: invalid memory address or nil pointer dereference`.